### PR TITLE
ZSS-609: The input text box doesn't disappear when rename sheet bar with empty name and click another sheet

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -34,6 +34,7 @@ ZK Spreadsheet 3.5.0
   ZSS-649 After delete row, NameRange doesn't update
   ZSS-687 Formula that refer to a NameRange does not update contents correctly
   ZSS-514 if the font size is larger than 24, the text will overlap each other when using inline editor
+  ZSS-609 The input text box doesn't disappear when rename sheet bar with empty name and click another sheet
   
 ** Upgrade Notes
   * Following api are deprecated

--- a/zss.test/src/main/webapp/issue/609-empty-sheet-name.zul
+++ b/zss.test/src/main/webapp/issue/609-empty-sheet-name.zul
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+609-empty-sheet-name.zul
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Thu, Jun 12, 2014  7:01:07 PM, Created by RaymondChao
+
+Copyright (C) 2014 Potix Corporation. All Rights Reserved.
+
+-->
+<window>
+	<label multiline="true">
+		1. rename Sheet1 to "" (empty)
+		2. click Sheet2
+		3. it should show warning and reset sheet name to "Sheet1"
+	</label>
+	<spreadsheet id="ss" src="/issue/blank.xlsx" 
+		showSheetbar="true" height="500px" width="500px">
+	</spreadsheet>
+</window>

--- a/zss/src/archive/web/js/zss/Sheetbar.js
+++ b/zss/src/archive/web/js/zss/Sheetbar.js
@@ -168,8 +168,9 @@ zss.SheetTab = zk.$extends(zul.tab.Tab, {
 		
 		var name = this.getLabel(),
 			text = this.textbox.getText();
-		if (!text)
-			return;
+		// ZSS-609: let component determine if the sheet name is legal
+		//if (!text)
+		//	return;
 		
 		if (name != text) {
 			var wgt = this._wgt;


### PR DESCRIPTION
http://tracker.zkoss.org/browse/ZSS-609
