### PR TITLE
Bug fixed ZSS-632: mailto link should not appear in web address textbox in "Insert Hyperlink" dialog

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -55,6 +55,7 @@ ZK Spreadsheet 3.5.0
   ZSS-707 The sorting order of AutoFilter dropdown is not correct.
   ZSS-689 Edit cell formula and use mouse to select a merged cell, it will insert range
   ZSS-579 Undo doesn't notify toolbar button to change status
+  ZSS-632 mailto link should not appear in web address textbox in "Insert Hyperlink" dialog
   
 ** Upgrade Notes
   * Following api are deprecated

--- a/zss.test/src/main/webapp/issue3/632-insert-mail.zul
+++ b/zss.test/src/main/webapp/issue3/632-insert-mail.zul
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+632-insert-mail.zul
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Mon, Jun 30, 2014  7:04:34 PM, Created by RaymondChao
+
+Copyright (C) 2014 Potix Corporation. All Rights Reserved.
+
+-->
+<window>
+	<label multiline="true">
+		1. insert a mailto link (john@abc.com) by toolbar button in A1
+		2. select A1, click "Insert Hyperlink" toolbar button
+		3. "E-mail Address" textbox contains the mailto link I just entered
+	</label>
+	<spreadsheet src="/issue/blank.xlsx" showToolbar="true" height="600px" width="800px" />
+</window>
+


### PR DESCRIPTION
http://tracker.zkoss.org/browse/ZSS-632
