### PR TITLE
Bug ZSS-762: context menu on sheet bar may be closed when we right click on the inactive sheet tab

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -31,6 +31,7 @@ ZK Spreadsheet 3.5.1
   ZSS-752 Failed to apply style to a cell with rich text correctly.
   ZSS-756 Unexpected messagebox showed in the Insert Function Window
   ZSS-743 Possible performance impact due to formula re-evaluation
+  ZSS-762 context menu on sheet bar may be closed when we right click on the inactive sheet tab
   
 ** Upgrade Notes
   * Following api are deprecated

--- a/zss/src/archive/web/js/zss/SSheetCtrl.js
+++ b/zss/src/archive/web/js/zss/SSheetCtrl.js
@@ -1392,9 +1392,9 @@ zss.SSheetCtrl = zk.$extends(zk.Widget, {
 		var dataPanel = this.dp;
 		// ZSS-681: focus textarea before open stylepanel
 		if (typeof dataPanel.selectFocustagId == "number") {
-			dataPanel.selectFocustag();
 			window.clearTimeout(dataPanel.selectFocustagId);
 			delete dataPanel.selectFocustagId;
+			dataPanel.selectFocustag();
 		}
 		this._doMouseclick(evt, "rc");
 		evt.stop();//always stop right (context) click.

--- a/zss/src/archive/web/js/zss/Sheetbar.js
+++ b/zss/src/archive/web/js/zss/Sheetbar.js
@@ -398,6 +398,11 @@ zss.SheetSelector = zk.$extends(zul.tab.Tabbox, {
 		var tab = this.tabs.firstChild;
 		for (;tab; tab = tab.nextSibling) {
 			if (sheetId == tab.getSheetUuid()) {
+				var sheet = this._wgt.sheetCtrl;
+				if (sheet) {
+					// ZSS-762: blur spreadsheet to prevent it refocuses to inline editor
+					sheet.dp._doFocusLost();
+				}
 				this.setSelectedTab(tab);
 				break;
 			}


### PR DESCRIPTION
http://tracker.zkoss.org/browse/ZSS-762
